### PR TITLE
Fix path to self

### DIFF
--- a/src/main.sh
+++ b/src/main.sh
@@ -82,7 +82,7 @@ cd $project_name
 ###############################################################################
 
 # This finds the line number where the base64 encoded archive lies
-PAYLOAD_LINE=$(awk '/^__PAYLOAD_BEGINS__/ { print NR + 1; exit 0; }' $0)
+PAYLOAD_LINE=$(awk '/^__PAYLOAD_BEGINS__/ { print NR + 1; exit 0; }' $SELF)
 
 # This bit does a few things in one line
 #


### PR DESCRIPTION
When we're looking for the line number where the payload begins we've already moved into the generated directory, so we can't fine ./cpp_project, can fix this by using the SELF variable defined earlier instead of $0.